### PR TITLE
[RFC] Make additional RSA blinding optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ hasher.input(message);
 let digest = hasher.result();
 
 // Obtain a signture
-let signature = rsa_fdh::sign::<Sha256, _>(&mut rng, &signer_priv_key, &digest)?;
+let signature = rsa_fdh::sign::<Sha256, _>(Some(&mut rng), &signer_priv_key, &digest)?;
 
 // Verify the signature
 rsa_fdh::verify::<Sha256, _>(&signer_pub_key, &digest, &signature)?;
@@ -72,7 +72,7 @@ let digest = blind::hash_message::<Sha256, _>(&signer_pub_key, message)?;
 let (blinded_digest, unblinder) = blind::blind(&mut rng, &signer_pub_key, &digest);
 
 // Send the blinded-digest to the signer and get their signature
-let blind_signature = blind::sign(&mut rng, &signer_priv_key, &blinded_digest)?;
+let blind_signature = blind::sign(Some(&mut rng), &signer_priv_key, &blinded_digest)?;
 
 // Unblind the signature
 let signature = blind::unblind(&signer_pub_key, &blind_signature, &unblinder);
@@ -122,5 +122,5 @@ Two signature schemes are supported:
 Blinding, unblinding, signing and verification are done in the usual way for RSA.
 
  ## Contributors
- 
+
  1. Patrick Hayes ([linkedin](https://www.linkedin.com/in/patrickdhayes/)) ([github](https://github.com/phayes)) - Available for hire.

--- a/src/blind.rs
+++ b/src/blind.rs
@@ -24,7 +24,7 @@
 //! let (blinded_digest, unblinder) = blind::blind(&mut rng, &signer_pub_key, &digest);
 //!
 //! // Send the blinded-digest to the signer and get their signature
-//! let blind_signature = blind::sign(&mut rng, &signer_priv_key, &blinded_digest).unwrap();
+//! let blind_signature = blind::sign(Some(&mut rng), &signer_priv_key, &blinded_digest).unwrap();
 //!
 //! // Unblind the signature
 //! let signature = blind::unblind(&signer_pub_key, &blind_signature, &unblinder);
@@ -97,7 +97,7 @@ mod tests {
             let (blinded_digest, unblinder) = blind::blind(&mut rng, &signer_pub_key, &digest);
 
             // Send the blinded-digest to the signer and get their signature
-            let blind_signature = blind::sign(&mut rng, &signer_priv_key, &blinded_digest)?;
+            let blind_signature = blind::sign(Some(&mut rng), &signer_priv_key, &blinded_digest)?;
 
             // Assert the the blind signature does not validate against the orignal digest.
             assert!(blind::verify(&signer_pub_key, &digest, &blind_signature).is_err());
@@ -129,13 +129,13 @@ mod tests {
         let key_1 = RSAPrivateKey::new(&mut rng, 256).unwrap();
         let digest_1 = blind::hash_message::<Sha256, _>(&key_1, message)?;
         let (blinded_digest_1, unblinder_1) = blind::blind(&mut rng, &key_1, &digest_1);
-        let blind_signature_1 = blind::sign(&mut rng, &key_1, &blinded_digest_1)?;
+        let blind_signature_1 = blind::sign(Some(&mut rng), &key_1, &blinded_digest_1)?;
         let signature_1 = blind::unblind(&key_1, &blind_signature_1, &unblinder_1);
 
         let key_2 = RSAPrivateKey::new(&mut rng, 512).unwrap();
         let digest_2 = blind::hash_message::<Sha256, _>(&key_2, message)?;
         let (blinded_digest_2, unblinder_2) = blind::blind(&mut rng, &key_2, &digest_2);
-        let blind_signature_2 = blind::sign(&mut rng, &key_2, &blinded_digest_2)?;
+        let blind_signature_2 = blind::sign(Some(&mut rng), &key_2, &blinded_digest_2)?;
         let signature_2 = blind::unblind(&key_2, &blind_signature_2, &unblinder_2);
 
         // Assert that everything is differnet
@@ -146,7 +146,7 @@ mod tests {
         assert!(signature_1 != signature_2);
 
         // Assert that they don't cross validate
-        assert!(blind::sign(&mut rng, &key_1, &blinded_digest_2).is_err());
+        assert!(blind::sign(Some(&mut rng), &key_1, &blinded_digest_2).is_err());
         assert!(blind::verify(&key_1, &digest_1, &signature_2).is_err());
         assert!(blind::verify(&key_1, &digest_2, &signature_1).is_err());
         assert!(blind::verify(&key_1, &digest_2, &signature_2).is_err());

--- a/src/common.rs
+++ b/src/common.rs
@@ -80,7 +80,7 @@ pub fn verify_hashed<K: PublicKey>(pub_key: &K, hashed: &[u8], sig: &[u8]) -> Re
 
 /// Sign the given blinded digest.
 pub fn sign_hashed<R: Rng>(
-  rng: &mut R,
+  rng: Option<&mut R>,
   priv_key: &RSAPrivateKey,
   hashed: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -95,7 +95,7 @@ pub fn sign_hashed<R: Rng>(
     return Err(Error::DigestTooLarge);
   }
 
-  let c = internals::decrypt_and_check(Some(rng), priv_key, &m)
+  let c = internals::decrypt_and_check(rng, priv_key, &m)
     .map_err(Error::RSAError)?
     .to_bytes_be();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! use sha2::{Sha256, Digest};
 //!
 //! // Set up rng and message
-//! let mut rng = rand::thread_rng();;
+//! let mut rng = rand::thread_rng();
 //! let message = b"NEVER GOING TO GIVE YOU UP";
 //!
 //! // Create the keys
@@ -26,7 +26,7 @@
 //! let digest = hasher.result();
 //!
 //! // Obtain a signture
-//! let signature = rsa_fdh::sign::<Sha256, _>(&mut rng, &signer_priv_key, &digest).unwrap();
+//! let signature = rsa_fdh::sign::<Sha256, _>(Some(&mut rng), &signer_priv_key, &digest).unwrap();
 //!
 //! // Verify the signature
 //! let ok = rsa_fdh::verify::<Sha256, _>(&signer_pub_key, &digest, &signature);
@@ -47,7 +47,7 @@ pub use common::Error;
 /// The signer will apply RSA-FDH padding before singing the message.
 /// The resulting signature is not a blind signature.
 pub fn sign<H: digest::Digest + Clone, R: Rng>(
-    rng: &mut R,
+    rng: Option<&mut R>,
     priv_key: &RSAPrivateKey,
     message: &[u8],
 ) -> Result<Vec<u8>, Error> {
@@ -95,7 +95,7 @@ mod tests {
 
         // Do this a bunch so that we get a good sampling of possibe digests.
         for _ in 0..500 {
-            let signature = rsa_fdh::sign::<Sha256, _>(&mut rng, &signer_priv_key, &digest)?;
+            let signature = rsa_fdh::sign::<Sha256, _>(Some(&mut rng), &signer_priv_key, &digest)?;
             rsa_fdh::verify::<Sha256, _>(&signer_pub_key, &digest, &signature)?;
         }
 
@@ -114,10 +114,10 @@ mod tests {
 
         // Create the keys
         let key_1 = RSAPrivateKey::new(&mut rng, 256).unwrap();
-        let signature_1 = rsa_fdh::sign::<Sha256, _>(&mut rng, &key_1, &digest)?;
+        let signature_1 = rsa_fdh::sign::<Sha256, _>(Some(&mut rng), &key_1, &digest)?;
 
         let key_2 = RSAPrivateKey::new(&mut rng, 512).unwrap();
-        let signature_2 = rsa_fdh::sign::<Sha256, _>(&mut rng, &key_2, &digest)?;
+        let signature_2 = rsa_fdh::sign::<Sha256, _>(Some(&mut rng), &key_2, &digest)?;
 
         // Assert that signatures are different
         assert!(signature_1 != signature_2);


### PR DESCRIPTION
Hey @phayes, thanks for creating this set of libraries! Really cool work!

As mentioned in https://github.com/phayes/fdh-rs/issues/16#issuecomment-597054997, in our application the signatures must be deterministic.

As such, I've made it optional to pass a RNG to the `sign` and `sign_hashed` functions.

I've made the code changes, but didn't write any new tests yet. So far, this is just an RFC PR. What do you think?